### PR TITLE
Arbitrary transformation matrices

### DIFF
--- a/include/polyhedron.h
+++ b/include/polyhedron.h
@@ -1,6 +1,8 @@
 #ifndef POLYHEDRON_H
 #define POLYHEDRON_H
 
+#define BOOST_PYTHON_MAX_ARITY 16
+
 #include<iostream>
 #include<stdexcept>
 #include<boost/python.hpp>
@@ -215,6 +217,16 @@ public:
 	 */
 	polyhedron scale( const double x, const double y, const double z ) const;
 			
+
+polyhedron multmatrix3( double xx,double xy,double xz,
+                        double yx,double yy,double yz,
+                        double zx,double zy,double zz ) const;
+
+polyhedron multmatrix4( double xx,double xy,double xz, double xa,
+                        double yx,double yy,double yz, double ya,
+                        double zx,double zy,double zz, double za,
+                        double ax,double ay,double az, double aa ) const;
+
 	/**
 	 @brief polyhedron union operator, takes an input polyhedron and returns the union of this polyhedron with it
 	 @param[in] in input polyhedron to compute union with
@@ -301,6 +313,7 @@ polyhedron cone( const double radius, const double height, const bool is_centere
  @return generated polyhedron or an empty polyhedron otherwise
 */
 polyhedron torus( const double radius_major, const double radius_minor, const bool is_centered=false, const int major_segments=20, const int minor_segments=20 );
+
 
 
 #endif

--- a/include/polyhedron_unary_op.h
+++ b/include/polyhedron_unary_op.h
@@ -96,4 +96,50 @@ public:
 	polyhedron operator()( const polyhedron &in );
 };
 
+class polyhedron_multmatrix3 : public polyhedron_unary_op
+{
+    private:
+        /** @brief matrix to apply */
+        double m_matrix[3][3];
+    public:
+        /**
+         @brief constructor, takes a list of matrix elements as arguments
+         */
+        polyhedron_multmatrix3( const double xx,const double xy,const double xz,
+                                const double yx,const double yy,const double yz,
+                                const double zx,const double zy,const double zz );
+
+        /**
+         @brief applies the matrix multiplication
+         @param[in] an input polyhedron
+         @return polyhedron transformed by m_matrix
+         */
+        polyhedron operator()( const polyhedron &in );
+};
+
+class polyhedron_multmatrix4 : public polyhedron_unary_op
+{
+    private:
+        /** @brief matrix to apply */
+        double m_matrix[3][3];
+        /** @brief translation to apply */
+        double m_translation[3];
+    public:
+        /**
+         @brief constructor, takes a list of matrix elements as arguments
+         */
+
+        polyhedron_multmatrix4(
+            const double xx,const double xy,const double xz, const double xa,
+            const double yx,const double yy,const double yz, const double ya,
+            const double zx,const double zy,const double zz, const double za,
+            const double ax,const double ay,const double az, const double aa );
+        /**
+         @brief applies the matrix multiplication
+         @param[in] an input polyhedron
+         @return polyhedron transformed by m_matrix
+         */
+        polyhedron operator()( const polyhedron &in );
+};
+
 #endif

--- a/scripts/multmatrix_text.py
+++ b/scripts/multmatrix_text.py
@@ -1,0 +1,19 @@
+from pyPolyCSG import *
+
+cube = polyhedron()
+cube.make_box(2,2,2,True);
+
+cube = cube.multmatrix3(20,0,0,
+                        0,3,0,
+                        0,0,0.5);
+cube.save_mesh("multmatrix3.stl");
+
+cube.make_box(2,2,2,True);
+
+cube = cube.multmatrix4( 20, 0, 0,   10,
+                         0,  3, 0,   4,
+                         0,  0, 0.5, 4,
+                         0,  0, 0,   1);
+
+cube.save_mesh("multmatrix4.obj");
+

--- a/source/polyhedron.cpp
+++ b/source/polyhedron.cpp
@@ -578,6 +578,30 @@ polyhedron polyhedron::scale( const double x, const double y, const double z ) c
 	return op( *this );
 }
 
+polyhedron polyhedron::multmatrix4(
+                        double xx, double xy, double xz, double xa,
+                        double yx, double yy, double yz, double ya,
+                        double zx, double zy, double zz, double za,
+                        double ax, double ay, double az, double aa ) const {
+    polyhedron_multmatrix4 op( xx, xy, xz, xa,
+                               yx, yy, yz, ya,
+                               zx, zy, zz, za,
+                               ax, ay, az, aa );
+
+    return op( *this );
+}
+
+polyhedron polyhedron::multmatrix3(
+        double xx,double xy,double xz,
+        double yx,double yy,double yz,
+        double zx,double zy,double zz ) const {
+    polyhedron_multmatrix3 op( xx, xy, xz,
+                               yx, yy, yz,
+                               zx, zy, zz );
+
+    return op( *this );
+}
+
 polyhedron polyhedron::operator+( const polyhedron &in ) const {
 	polyhedron_union op;
 	return op( *this, in );

--- a/source/polyhedron_unary_op.cpp
+++ b/source/polyhedron_unary_op.cpp
@@ -90,3 +90,59 @@ polyhedron polyhedron_scale::operator()( const polyhedron &in ){
 	return ret;
 }
 
+polyhedron_multmatrix3::polyhedron_multmatrix3(
+        const double xx,const double xy,const double xz,
+        const double yx,const double yy,const double yz,
+        const double zx,const double zy,const double zz ) {
+    m_matrix[0][0] = xx; m_matrix[0][1] = xy; m_matrix[0][2] = xz;
+    m_matrix[1][0] = yx; m_matrix[1][1] = yy; m_matrix[1][2] = yz;
+    m_matrix[2][0] = zx; m_matrix[2][1] = zy; m_matrix[2][2] = zz;
+}
+
+polyhedron polyhedron_multmatrix3::operator()( const polyhedron &in ) {
+	std::vector<double> coords;
+	std::vector<int>    faces;
+	in.output_store_in_mesh( coords, faces );
+	for( int i=0; i<(int)coords.size(); i+=3 ){
+		double x=coords[i+0], y=coords[i+1], z=coords[i+2];
+		coords[i+0] = m_matrix[0][0]*x + m_matrix[0][1]*y + m_matrix[0][2]*z;
+		coords[i+1] = m_matrix[1][0]*x + m_matrix[1][1]*y + m_matrix[1][2]*z;
+		coords[i+2] = m_matrix[2][0]*x + m_matrix[2][1]*y + m_matrix[2][2]*z;
+	}
+	polyhedron ret;
+	ret.initialize_load_from_mesh( coords, faces );
+	return ret;
+};
+
+polyhedron_multmatrix4::polyhedron_multmatrix4(
+        const double xx, const double xy, const double xz, const double xa,
+        const double yx, const double yy, const double yz, const double ya,
+        const double zx, const double zy, const double zz, const double za,
+        const double ax, const double ay, const double az, const double aa ) {
+    m_matrix[0][0] = xx; m_matrix[0][1] = xy; m_matrix[0][2] = xz;
+    m_matrix[1][0] = yx; m_matrix[1][1] = yy; m_matrix[1][2] = yz;
+    m_matrix[2][0] = zx; m_matrix[2][1] = zy; m_matrix[2][2] = zz;
+
+    m_translation[0] = xa;
+    m_translation[1] = ya;
+    m_translation[2] = za;
+}
+
+polyhedron polyhedron_multmatrix4::operator()( const polyhedron &in ) {
+	std::vector<double> coords, new_coords;
+	std::vector<int>    faces;
+	in.output_store_in_mesh( coords, faces );
+  new_coords.resize(coords.size());
+	for( int offset=0; offset<(int)coords.size(); offset+=3 ){
+    for ( int j=0; j<3; j++ ) {
+        for ( int k=0; k<3; k++ ) {
+            new_coords[offset+j] += m_matrix[j][k] * coords[offset+j];
+        }
+    }
+	}
+  polyhedron_translate* translate = new polyhedron_translate(m_translation[0], m_translation[1], m_translation[2]);
+	polyhedron ret;
+	ret.initialize_load_from_mesh( new_coords, faces );
+  ret = (*translate)(ret);
+	return ret;
+}

--- a/source/polyhedron_unary_op.cpp
+++ b/source/polyhedron_unary_op.cpp
@@ -91,12 +91,12 @@ polyhedron polyhedron_scale::operator()( const polyhedron &in ){
 }
 
 polyhedron_multmatrix3::polyhedron_multmatrix3(
-        const double xx,const double xy,const double xz,
-        const double yx,const double yy,const double yz,
-        const double zx,const double zy,const double zz ) {
-    m_matrix[0][0] = xx; m_matrix[0][1] = xy; m_matrix[0][2] = xz;
-    m_matrix[1][0] = yx; m_matrix[1][1] = yy; m_matrix[1][2] = yz;
-    m_matrix[2][0] = zx; m_matrix[2][1] = zy; m_matrix[2][2] = zz;
+		const double xx,const double xy,const double xz,
+		const double yx,const double yy,const double yz,
+		const double zx,const double zy,const double zz ) {
+	m_matrix[0][0] = xx; m_matrix[0][1] = xy; m_matrix[0][2] = xz;
+	m_matrix[1][0] = yx; m_matrix[1][1] = yy; m_matrix[1][2] = yz;
+	m_matrix[2][0] = zx; m_matrix[2][1] = zy; m_matrix[2][2] = zz;
 }
 
 polyhedron polyhedron_multmatrix3::operator()( const polyhedron &in ) {
@@ -115,30 +115,30 @@ polyhedron polyhedron_multmatrix3::operator()( const polyhedron &in ) {
 };
 
 polyhedron_multmatrix4::polyhedron_multmatrix4(
-        const double xx, const double xy, const double xz, const double xa,
-        const double yx, const double yy, const double yz, const double ya,
-        const double zx, const double zy, const double zz, const double za,
-        const double ax, const double ay, const double az, const double aa ) {
-    m_matrix[0][0] = xx; m_matrix[0][1] = xy; m_matrix[0][2] = xz;
-    m_matrix[1][0] = yx; m_matrix[1][1] = yy; m_matrix[1][2] = yz;
-    m_matrix[2][0] = zx; m_matrix[2][1] = zy; m_matrix[2][2] = zz;
+		const double xx, const double xy, const double xz, const double xa,
+		const double yx, const double yy, const double yz, const double ya,
+		const double zx, const double zy, const double zz, const double za,
+		const double ax, const double ay, const double az, const double aa ) {
+	m_matrix[0][0] = xx; m_matrix[0][1] = xy; m_matrix[0][2] = xz;
+	m_matrix[1][0] = yx; m_matrix[1][1] = yy; m_matrix[1][2] = yz;
+	m_matrix[2][0] = zx; m_matrix[2][1] = zy; m_matrix[2][2] = zz;
 
-    m_translation[0] = xa;
-    m_translation[1] = ya;
-    m_translation[2] = za;
+	m_translation[0] = xa;
+	m_translation[1] = ya;
+	m_translation[2] = za;
 }
 
 polyhedron polyhedron_multmatrix4::operator()( const polyhedron &in ) {
 	std::vector<double> coords, new_coords;
-	std::vector<int>    faces;
+	std::vector<int>	faces;
 	in.output_store_in_mesh( coords, faces );
   new_coords.resize(coords.size());
 	for( int offset=0; offset<(int)coords.size(); offset+=3 ){
-    for ( int j=0; j<3; j++ ) {
-        for ( int k=0; k<3; k++ ) {
-            new_coords[offset+j] += m_matrix[j][k] * coords[offset+j];
-        }
-    }
+	for ( int j=0; j<3; j++ ) {
+		for ( int k=0; k<3; k++ ) {
+			new_coords[offset+j] += m_matrix[j][k] * coords[offset+j];
+		}
+	}
 	}
   polyhedron_translate* translate = new polyhedron_translate(m_translation[0], m_translation[1], m_translation[2]);
 	polyhedron ret;

--- a/source/python_wrapper.cpp
+++ b/source/python_wrapper.cpp
@@ -34,6 +34,8 @@ BOOST_PYTHON_MODULE(pyPolyCSG){
 	.def( "translate",                 &polyhedron::translate )
 	.def( "rotate",                    &polyhedron::rotate )
 	.def( "scale",                     &polyhedron::scale )
+	.def( "multmatrix3",               &polyhedron::multmatrix3 )
+	.def( "multmatrix4",               &polyhedron::multmatrix4 )
 	.def( "save_mesh",                 &polyhedron::output_store_in_file )
     
     .def( "num_vertices",              &polyhedron::num_vertices )


### PR DESCRIPTION
The application I am working with provides raw transformation matrices for a lot of the operations it wants to do, many of which are based on the primitive transformations (rotate, translate, scale, etc), however, quite a few of them have already been pre-optimized and rather than trying to divine the original pairs and triplets of matrices, I opted to implement a generic transformation matrix method, both for 3x3 and 4x4 (3x3+translation) matrices.

This code uses the matrix application from the rotate method, and we could easily make rotate() use this matrix method to reduce duplication. 
