### PR TITLE
Extrusion and clyinder exports

### DIFF
--- a/include/polyhedron.h
+++ b/include/polyhedron.h
@@ -271,6 +271,8 @@ polyhedron sphere( const double radius, const bool is_centered=false, const int 
 */
 polyhedron box( const double size_x, const double size_y, const double size_z, const bool is_centered=false );
 
+polyhedron extrusion( const std::vector<double> &coords, const std::vector<int> &lines, const double distance );
+
 /**
  @brief convenience function for creating a cylinder, wraps polyhedron::initialize_create_cylinder()
  @param[in] radius cylinder radius

--- a/source/polyhedron.cpp
+++ b/source/polyhedron.cpp
@@ -44,6 +44,12 @@ polyhedron torus( const double radius_major, const double radius_minor, const bo
 	return p;
 }
 
+polyhedron extrusion( const std::vector<double> &coords, const std::vector<int> &lines, const double distance ){
+	polyhedron p;
+	p.initialize_create_extrusion( coords, lines, distance );
+	return p;
+}
+
 
 polyhedron::polyhedron(){
 	m_coords.clear();

--- a/source/python_wrapper.cpp
+++ b/source/python_wrapper.cpp
@@ -1,4 +1,5 @@
 #include<boost/python.hpp>
+#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 using namespace boost::python;
 
 #include"polyhedron.h"
@@ -8,12 +9,14 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS( make_box_overloads,			initialize_create_
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS( make_cylinder_overloads,    initialize_create_cylinder,  2, 4 );
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS( make_cone_overloads,		initialize_create_cone,      2, 4 );
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS( make_torus_overloads,		initialize_create_torus,     2, 5 );
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS( make_extrusion_overloads,		initialize_create_extrusion,     3,3 );
 
 BOOST_PYTHON_FUNCTION_OVERLOADS( sphere_overloads,   sphere,   1, 4 );
 BOOST_PYTHON_FUNCTION_OVERLOADS( box_overloads,      box,      3, 4 );
 BOOST_PYTHON_FUNCTION_OVERLOADS( cylinder_overloads, cylinder, 2, 4 );
 BOOST_PYTHON_FUNCTION_OVERLOADS( cone_overloads,     cone,     2, 4 );
 BOOST_PYTHON_FUNCTION_OVERLOADS( torus_overloads,    torus,    2, 5 );
+BOOST_PYTHON_FUNCTION_OVERLOADS( extrusion_overloads,    extrusion,    3,3 );
 
 BOOST_PYTHON_MODULE(pyPolyCSG){
 	numeric::array::set_module_and_type("numpy", "ndarray");
@@ -24,6 +27,7 @@ BOOST_PYTHON_MODULE(pyPolyCSG){
 	def( "cylinder",	     cylinder,  cylinder_overloads() );
 	def( "cone",		     cone,      cone_overloads() );
 	def( "torus",		     torus,     torus_overloads() );
+	def( "extrusion",		     extrusion,     extrusion_overloads() );
 	
 	class_<polyhedron>("polyhedron")
 	.def( "load_mesh",	               &polyhedron::initialize_load_from_file )
@@ -31,6 +35,8 @@ BOOST_PYTHON_MODULE(pyPolyCSG){
 	.def( "make_box",                  &polyhedron::initialize_create_box,    make_box_overloads() )
 	.def( "make_cone",                 &polyhedron::initialize_create_cone,   make_cone_overloads() )
 	.def( "make_torus",                &polyhedron::initialize_create_torus,  make_torus_overloads() )
+	.def( "make_cylinder",                &polyhedron::initialize_create_cylinder,  make_cylinder_overloads() )
+	.def( "make_extrusion",                &polyhedron::initialize_create_extrusion,  make_extrusion_overloads() )
 	.def( "translate",                 &polyhedron::translate )
 	.def( "rotate",                    &polyhedron::rotate )
 	.def( "scale",                     &polyhedron::scale )
@@ -48,4 +54,10 @@ BOOST_PYTHON_MODULE(pyPolyCSG){
 	.def( self - polyhedron() )
 	.def( self * polyhedron() )
 	;
+
+boost::python::class_<std::vector<double> >("DoubleVec")
+  .def(boost::python::vector_indexing_suite<std::vector<double> >());
+boost::python::class_<std::vector<int> >("IntVec")
+  .def(boost::python::vector_indexing_suite<std::vector<int> >());
 }
+


### PR DESCRIPTION
This pull request exposes code that essentially already exists within pyPolyCSG. I'm not really sure why they aren't exposed, and I imagine there is a good reason, I'm just curious to know what it is. 

the make_cylinder method is included simply to match the code processes which are already in place for other primitives. 

```
p = polyhedron()
p.make_box() #kosher!
p.make_cylinder() #method not found previously
```
